### PR TITLE
Fix navbar links in navbar for packages.html

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -19,7 +19,7 @@
     <!-- Navbar  -->
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
         <div class="container-fluid">
-            <a class="navbar-brand heading" href="#">TravelTrek</a>
+            <a class="navbar-brand heading" href="index.html">TravelTrek</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
                 aria-label="Toggle navigation">
@@ -36,19 +36,8 @@
                     <li class="nav-item">
                         <a class="nav-link" aria-disabled="true" href="what-to-do.html">What To Do</a>
                     </li>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"
-                            aria-expanded="false">
-                            Packages
-                        </a>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#">First Time Offer</a></li>
-                            <li><a class="dropdown-item" href="#">Deals</a></li>
-                            <li>
-                                <hr class="dropdown-divider">
-                            </li>
-                            <li><a class="dropdown-item" href="#">Find More</a></li>
-                        </ul>
+                    <li class="nav-item">
+                        <a class="nav-link" href="packages.html">Packages</a>
                     </li>
 
                 </ul>

--- a/index.html
+++ b/index.html
@@ -34,21 +34,10 @@
                         <a class="nav-link" href="destinations.html">Destinations</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" aria-disabled="true" href="what-to-do.html">What To Do</a>
+                        <a class="nav-link" href="what-to-do.html">What To Do</a>
                     </li>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"
-                            aria-expanded="false">
-                            Packages
-                        </a>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#">First Time Offer</a></li>
-                            <li><a class="dropdown-item" href="#">Deals</a></li>
-                            <li>
-                                <hr class="dropdown-divider">
-                            </li>
-                            <li><a class="dropdown-item" href="#">Find More</a></li>
-                        </ul>
+                    <li class="nav-item">
+                        <a class="nav-link" href="packages.html">Packages</a>
                     </li>
 
                 </ul>

--- a/packages.html
+++ b/packages.html
@@ -19,7 +19,7 @@
     <!-- Navbar  -->
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
         <div class="container-fluid">
-            <a class="navbar-brand heading" href="#">TravelTrek</a>
+            <a class="navbar-brand heading" href="index.html">TravelTrek</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
                 aria-label="Toggle navigation">

--- a/what-to-do.html
+++ b/what-to-do.html
@@ -36,19 +36,8 @@
                     <li class="nav-item">
                         <a class="nav-link" aria-disabled="true" href="what-to-do.html">What To Do</a>
                     </li>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="packages.html" role="button" data-bs-toggle="dropdown"
-                            aria-expanded="false">
-                            Packages
-                        </a>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#">First Time Offer</a></li>
-                            <li><a class="dropdown-item" href="#">Deals</a></li>
-                            <li>
-                                <hr class="dropdown-divider">
-                            </li>
-                            <li><a class="dropdown-item" href="#">Find More</a></li>
-                        </ul>
+                    <li class="nav-item">
+                        <a class="nav-link" href="packages.html">Packages</a>
                     </li>
 
                 </ul>


### PR DESCRIPTION
The navbar link for "Packages" on index, destinations and what-to-do have been converted to a standard <a> tag link.  The "Packages" link on packages.html has been kept as a dropdown.